### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_script_venturebeat.yml
+++ b/.github/workflows/run_script_venturebeat.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   run_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/genai-trending-to-bluesky/security/code-scanning/4](https://github.com/aegisfleet/genai-trending-to-bluesky/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `actions: read` for downloading and uploading artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `run_script` job to limit permissions specifically for that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
