### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_script_techblog.yml
+++ b/.github/workflows/run_script_techblog.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 7 * * *'
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   run_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/genai-trending-to-bluesky/security/code-scanning/3](https://github.com/aegisfleet/genai-trending-to-bluesky/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: read` for checking out the repository.
- `actions: write` for downloading and uploading artifacts.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
